### PR TITLE
fix(core): publish jspecify nullability contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,7 @@ jobs:
             clean verify
 
       - name: Verify Maven Kotlin consumer
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="$(sh ./scripts/version.sh)"
-          mvn --batch-mode --no-transfer-progress \
-            -f smoke-test-maven-kotlin/pom.xml \
-            -Dcodes.version="$version" \
-            -Dkotlin.version=2.4.10 \
-            clean verify
+        run: sh ./scripts/verify-kotlin-nullability.sh 2.4.10
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
@@ -92,16 +84,8 @@ jobs:
       - name: Publish core locally
         run: ./gradlew publishToMavenLocal --stacktrace
 
-      - name: Compile and run Kotlin consumer
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="$(sh ./scripts/version.sh)"
-          mvn --batch-mode --no-transfer-progress \
-            -f smoke-test-maven-kotlin/pom.xml \
-            -Dcodes.version="$version" \
-            -Dkotlin.version="${{ matrix.kotlin }}" \
-            clean verify
+      - name: Verify Kotlin consumer
+        run: sh ./scripts/verify-kotlin-nullability.sh "${{ matrix.kotlin }}"
 
   kotlin-consumers-gate:
     name: Kotlin consumers gate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,15 +65,13 @@ jobs:
         run: |
           set -euo pipefail
           version="$(sh ./scripts/version.sh)"
+
           mvn --batch-mode --no-transfer-progress \
             -f smoke-test-maven-java/pom.xml \
             -Dcodes.version="$version" \
             clean verify
-          mvn --batch-mode --no-transfer-progress \
-            -f smoke-test-maven-kotlin/pom.xml \
-            -Dcodes.version="$version" \
-            -Dkotlin.version=2.4.10 \
-            clean verify
+
+          sh ./scripts/verify-kotlin-nullability.sh 2.4.10
 
       - name: Publish Codes core to Maven Central
         run: ./gradlew publishToMavenCentral --no-configuration-cache --stacktrace

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Maven:
 </dependency>
 ```
 
-Java 17+. The core is implemented in Java and has no runtime dependencies. Kotlin applications consume the same Java API without bringing a Codes-owned Kotlin runtime dependency.
+Java 17+. The core is implemented in Java. Kotlin applications consume the same Java API without bringing a Codes-owned Kotlin runtime dependency.
 
 ## Custom outcomes
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     api("org.jspecify:jspecify:1.0.0")
     testImplementation(platform("org.junit:junit-bom:${providers.gradleProperty("junitVersion").get()}"))
     testImplementation("org.junit.jupiter:junit-jupiter")
-    testImplementation("org.jspecify:jspecify:1.0.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 dependencies {
-    compileOnly("org.jspecify:jspecify:1.0.0")
+    api("org.jspecify:jspecify:1.0.0")
     testImplementation(platform("org.junit:junit-bom:${providers.gradleProperty("junitVersion").get()}"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.jspecify:jspecify:1.0.0")
@@ -62,25 +62,28 @@ tasks.jacocoTestCoverageVerification {
 
 tasks.register("verifyCoreRuntimeDependencies") {
     group = "verification"
-    description = "Fails when the Codes core artifact gains a runtime dependency."
+    description = "Fails when Codes core gains runtime dependencies other than JSpecify."
 
     val runtimeClasspath: Provider<out FileCollection> = configurations.runtimeClasspath
     inputs.files(runtimeClasspath)
 
     doLast {
-        val runtimeFiles = runtimeClasspath.get().files
+        val runtimeFiles = runtimeClasspath.get()
+            .files
+            .map { it.name }
+            .sorted()
 
-        check(runtimeFiles.isEmpty()) {
-            "Codes core must remain dependency-free at runtime: ${
-                runtimeFiles.joinToString { it.name }
+        check(runtimeFiles == listOf("jspecify-1.0.0.jar")) {
+            "Codes core runtime dependencies must be limited to JSpecify: ${
+                runtimeFiles.joinToString()
             }"
         }
     }
 }
 
-tasks.register("verifyPublishedPomHasNoDependencies") {
+tasks.register("verifyPublishedPomDependencies") {
     group = "verification"
-    description = "Fails when the published Codes Maven POM declares dependencies."
+    description = "Verifies the published Codes Maven dependency contract."
 
     dependsOn("generatePomFileForMavenPublication")
 
@@ -88,10 +91,34 @@ tasks.register("verifyPublishedPomHasNoDependencies") {
     inputs.file(pomFile)
 
     doLast {
-        val pom = pomFile.get().asFile.readText()
+        val document = javax.xml.parsers.DocumentBuilderFactory
+            .newInstance()
+            .newDocumentBuilder()
+            .parse(pomFile.get().asFile)
 
-        check("<dependencies>" !in pom) {
-            "Codes core Maven POM must not declare dependencies."
+        val dependencies = document.getElementsByTagName("dependency")
+
+        check(dependencies.length == 1) {
+            "Codes core Maven POM must declare only JSpecify; found ${dependencies.length} dependencies."
+        }
+
+        val dependency = dependencies.item(0) as org.w3c.dom.Element
+
+        fun value(name: String): String =
+            dependency.getElementsByTagName(name)
+                .item(0)
+                ?.textContent
+                ?.trim()
+                .orEmpty()
+
+        check(
+            value("groupId") == "org.jspecify"
+                && value("artifactId") == "jspecify"
+                && value("version") == "1.0.0"
+                && value("scope") == "compile"
+                && value("optional").isEmpty()
+        ) {
+            "Codes core Maven POM must expose org.jspecify:jspecify:1.0.0 as a non-optional compile dependency."
         }
     }
 }
@@ -99,7 +126,7 @@ tasks.register("verifyPublishedPomHasNoDependencies") {
 tasks.check {
     dependsOn(tasks.jacocoTestCoverageVerification)
     dependsOn(tasks.named("verifyCoreRuntimeDependencies"))
-    dependsOn(tasks.named("verifyPublishedPomHasNoDependencies"))
+    dependsOn(tasks.named("verifyPublishedPomDependencies"))
 }
 
 tasks.withType<AbstractArchiveTask>().configureEach {

--- a/docs/compatibility-policy.md
+++ b/docs/compatibility-policy.md
@@ -5,7 +5,7 @@ Codes is pre-1.0. Minor releases may contain source or binary breaking changes. 
 The published `codes` artifact:
 
 * targets Java 17;
-* has no runtime dependencies;
+* depends only on `org.jspecify:jspecify` for nullability annotations;
 * supports Java and Kotlin consumers.
 
 The following are part of the semantic contract:

--- a/scripts/verify-kotlin-nullability.sh
+++ b/scripts/verify-kotlin-nullability.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pom="$root_dir/smoke-test-maven-kotlin/pom.xml"
+source_dir="$root_dir/smoke-test-maven-kotlin/src/main/kotlin"
+
+kotlin_version="${1:?Usage: verify-kotlin-nullability.sh <kotlin-version>}"
+codes_version="$(sh "$root_dir/scripts/version.sh")"
+
+nullable_probe="$source_dir/NullableReturnProbe.kt"
+null_marked_probe="$source_dir/NullMarkedProbe.kt"
+output_file="$(mktemp)"
+
+trap 'rm -f "$nullable_probe" "$null_marked_probe" "$output_file"' EXIT
+
+mvn --batch-mode --no-transfer-progress \
+    -f "$pom" \
+    "-Dcodes.version=$codes_version" \
+    "-Dkotlin.version=$kotlin_version" \
+    clean verify
+
+cat > "$nullable_probe" <<'EOF'
+import io.github.aalsanie.codes.Outcome
+import io.github.aalsanie.codes.StandardOutcomes
+
+fun nullableReturnProbe() {
+    val outcome = Outcome.of(StandardOutcomes.NOT_FOUND)
+    val detail: String = outcome.detail
+    println(detail)
+}
+EOF
+
+cat > "$null_marked_probe" <<'EOF'
+import io.github.aalsanie.codes.Outcome
+
+fun nullMarkedProbe() {
+    Outcome.of(null)
+}
+EOF
+
+set +e
+
+mvn --batch-mode --no-transfer-progress --offline \
+    -f "$pom" \
+    "-Dcodes.version=$codes_version" \
+    "-Dkotlin.version=$kotlin_version" \
+    clean compile >"$output_file" 2>&1
+
+status=$?
+
+set -e
+
+cat "$output_file"
+
+if [[ $status -eq 0 ]]; then
+    echo "Expected Kotlin nullability probes to fail compilation." >&2
+    exit 1
+fi
+
+grep -Fq "NullableReturnProbe.kt" "$output_file" || {
+    echo "Nullable return contract was not rejected by the Kotlin compiler." >&2
+    exit 1
+}
+
+grep -Fq "NullMarkedProbe.kt" "$output_file" || {
+    echo "NullMarked parameter contract was not rejected by the Kotlin compiler." >&2
+    exit 1
+}
+
+echo "Kotlin $kotlin_version JSpecify nullability contract verified."

--- a/scripts/verify-kotlin-nullability.sh
+++ b/scripts/verify-kotlin-nullability.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
-root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+root_dir="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 pom="$root_dir/smoke-test-maven-kotlin/pom.xml"
 source_dir="$root_dir/smoke-test-maven-kotlin/src/main/kotlin"
 
@@ -12,13 +12,44 @@ nullable_probe="$source_dir/NullableReturnProbe.kt"
 null_marked_probe="$source_dir/NullMarkedProbe.kt"
 output_file="$(mktemp)"
 
-trap 'rm -f "$nullable_probe" "$null_marked_probe" "$output_file"' EXIT
+cleanup() {
+    rm -f "$nullable_probe" "$null_marked_probe" "$output_file"
+}
+trap cleanup EXIT HUP INT TERM
 
 mvn --batch-mode --no-transfer-progress \
     -f "$pom" \
     "-Dcodes.version=$codes_version" \
     "-Dkotlin.version=$kotlin_version" \
     clean verify
+
+expect_compile_failure() {
+    probe_file="$1"
+    : > "$output_file"
+
+    set +e
+    mvn --batch-mode --no-transfer-progress --offline \
+        -f "$pom" \
+        "-Dcodes.version=$codes_version" \
+        "-Dkotlin.version=$kotlin_version" \
+        clean compile >"$output_file" 2>&1
+    status=$?
+    set -e
+
+    cat "$output_file"
+
+    if [ "$status" -eq 0 ]; then
+        echo "Expected Kotlin compilation to reject $(basename "$probe_file")." >&2
+        exit 1
+    fi
+
+    if ! grep -Fq "$(basename "$probe_file")" "$output_file"; then
+        echo "Kotlin compilation failed for an unrelated reason while checking $(basename "$probe_file")." >&2
+        exit 1
+    fi
+
+    rm -f "$probe_file"
+}
 
 cat > "$nullable_probe" <<'EOF'
 import io.github.aalsanie.codes.Outcome
@@ -31,6 +62,8 @@ fun nullableReturnProbe() {
 }
 EOF
 
+expect_compile_failure "$nullable_probe"
+
 cat > "$null_marked_probe" <<'EOF'
 import io.github.aalsanie.codes.Outcome
 
@@ -39,33 +72,6 @@ fun nullMarkedProbe() {
 }
 EOF
 
-set +e
-
-mvn --batch-mode --no-transfer-progress --offline \
-    -f "$pom" \
-    "-Dcodes.version=$codes_version" \
-    "-Dkotlin.version=$kotlin_version" \
-    clean compile >"$output_file" 2>&1
-
-status=$?
-
-set -e
-
-cat "$output_file"
-
-if [[ $status -eq 0 ]]; then
-    echo "Expected Kotlin nullability probes to fail compilation." >&2
-    exit 1
-fi
-
-grep -Fq "NullableReturnProbe.kt" "$output_file" || {
-    echo "Nullable return contract was not rejected by the Kotlin compiler." >&2
-    exit 1
-}
-
-grep -Fq "NullMarkedProbe.kt" "$output_file" || {
-    echo "NullMarked parameter contract was not rejected by the Kotlin compiler." >&2
-    exit 1
-}
+expect_compile_failure "$null_marked_probe"
 
 echo "Kotlin $kotlin_version JSpecify nullability contract verified."

--- a/smoke-test-maven-kotlin/pom.xml
+++ b/smoke-test-maven-kotlin/pom.xml
@@ -35,9 +35,12 @@
             <id>compile</id>
             <phase>compile</phase>
             <goals><goal>compile</goal></goals>
-            <configuration>
-              <jvmTarget>17</jvmTarget>
-            </configuration>
+              <configuration>
+                  <jvmTarget>17</jvmTarget>
+                  <args>
+                      <arg>-Xjspecify-annotations=strict</arg>
+                  </args>
+              </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
- Publish JSpecify as the core's only dependency.
- Verify the published Maven dependency contract.
- Verify Kotlin nullability semantics against the published artifact.
- Enforce the contract across the Kotlin compiler matrix and release workflow.